### PR TITLE
refactor: change location of config-file for tests

### DIFF
--- a/gradle/testing.gradle.kts
+++ b/gradle/testing.gradle.kts
@@ -17,7 +17,7 @@ tasks.named<Test>("test") {
   // Configure environment variables for testing (as if they were initialized by start script)
   environment.putAll(mapOf(
       "GETEMALL_API_HOME" to "$projectDir",
-      "GETEMALL_API_CONF" to "$projectDir/conf"
+      "GETEMALL_API_CONF" to "$projectDir/src/test/resources/conf"
   ))
   // Configure system properties (not used, but just in case we need some special local library)
   systemProperties.putAll(mapOf(


### PR DESCRIPTION
#### Description
refactor: change location of config-file for tests.

Created a `conf` folder in test resources to keep a copy of app's conf file.
Also changed `testing.gradle.kts` to use the test conf-file instead of the main one during tests.