### PR TITLE
feat: implement readiness with login

### DIFF
--- a/src/main/kotlin/miquifant/getemall/api/controller/service.kt
+++ b/src/main/kotlin/miquifant/getemall/api/controller/service.kt
@@ -7,6 +7,9 @@ package miquifant.getemall.api.controller
 
 import miquifant.getemall.api.authentication.User
 import miquifant.getemall.api.authentication.UserDao
+import miquifant.getemall.api.controller.ComponentCheck.ComponentStatus
+import miquifant.getemall.api.controller.ComponentCheck.ComponentStatus.DOWN
+import miquifant.getemall.api.controller.ComponentCheck.ComponentStatus.OK
 import miquifant.getemall.log.Loggable.Logger
 import miquifant.getemall.log.LoggerFactory
 import miquifant.getemall.utils.*
@@ -26,22 +29,45 @@ object Admin {
   }
 }
 
-data class LoginState(val authFailed: Boolean,
+data class LoginState(val authError: Boolean,
+                      val authFailed: Boolean,
                       val authSucceeded: Boolean,
                       val loggedOut: Boolean,
                       val redirect: String?)
 {
   companion object {
-    const val AUTH_FAILED    = "loginState.authFailed"
+    const val AUTH_ERROR     = "loginState.authError"     // Log in service failed
+    const val AUTH_FAILED    = "loginState.authFailed"    // Wrong username or password
     const val AUTH_SUCCEEDED = "loginState.authSucceeded"
     const val LOGGED_OUT     = "loginState.loggedOut"
     const val REDIRECT       = "loginState.redirect"
   }
 }
 
+data class ComponentCheck(val status: ComponentStatus,
+                          val message: String? = null)
+{
+  enum class ComponentStatus { OK, DOWN }
+}
+
+data class ServiceReadiness(val status: ComponentStatus,
+                            val componentStatuses: Map<String, ComponentCheck>,
+                            val message: String? = null)
+
 object ServiceController {
 
   private val logger = LoggerFactory.logger(ServiceController::class.java.canonicalName)
+
+  fun checkLogin(dao: UserDao): ComponentCheck = try {
+
+    dao.getUserByUsername("admin")
+
+    ComponentCheck(OK)
+  } catch (e: Exception) {
+    val msg = "Login component not ready"
+    logger.errorWithThrowable(e) { msg }
+    ComponentCheck(DOWN, msg)
+  }
 
   val accessManager: (Logger) -> AccessManager = { accessLogger ->
     { handler, ctx, permittedRoles ->
@@ -102,6 +128,9 @@ object ServiceController {
   // ----------------------------------------------------------------------------------------------
   val loginState: Handler = { ctx ->
 
+    val authError = ctx.sessionAttribute(LoginState.AUTH_ERROR) ?: false
+    ctx.sessionAttribute(LoginState.AUTH_ERROR, null)
+
     val authFailed = ctx.sessionAttribute(LoginState.AUTH_FAILED) ?: false
     ctx.sessionAttribute(LoginState.AUTH_FAILED, null)
 
@@ -114,19 +143,37 @@ object ServiceController {
     val loginRedirect = ctx.sessionAttribute<String?>(LoginState.REDIRECT)
     ctx.sessionAttribute(LoginState.REDIRECT, null)
 
-    ctx.json(LoginState(authFailed, authSucceeded, loggedOut, loginRedirect))
+    ctx.json(LoginState(authError, authFailed, authSucceeded, loggedOut, loginRedirect))
   }
 
   val liveness: Handler = { ctx ->
     ctx.result("getemall is alive\n")
   }
-  val readiness: Handler = { ctx ->
-    // Add here all necessary checks
-    ctx.result("getemall is ready\n")
+
+  val readiness: (UserDao) -> Handler = { userDao ->
+    { ctx ->
+
+      // Check Login state
+      val loginStatus: ComponentCheck = checkLogin(userDao)
+
+      // Gather all component statuses
+      val componentStatuses = mapOf (
+          "login_check" to loginStatus
+      )
+      val serviceStatus = if (componentStatuses.values.any { check -> check.status == DOWN }) DOWN else OK
+      val response = ServiceReadiness (
+          serviceStatus,
+          componentStatuses,
+          "Service ${if (serviceStatus == OK) "is" else "NOT" } ready"
+      )
+      ctx.json(response)
+    }
   }
+
   val metadata: Handler = { ctx ->
     ctx.json(retrieveAppMetadata())
   }
+
   val kill: (Javalin) -> Handler = { app ->
     { ctx ->
       ctx.result("bye!\n")

--- a/src/main/kotlin/miquifant/getemall/api/controller/web.kt
+++ b/src/main/kotlin/miquifant/getemall/api/controller/web.kt
@@ -42,10 +42,16 @@ object LoginController {
     { ctx ->
 
       val loginRedirect = ctx.formParam("redirect")
-      val user = userDao.authenticate(ctx.formParam("username"), ctx.formParam("password"), accessLogger)
+      val (succeeded, user) = try {
 
+        Pair(true, userDao.authenticate(ctx.formParam("username"), ctx.formParam("password"), accessLogger))
+
+      } catch (e: Exception) {
+        Pair(false, null)
+      }
       if (user == null) {
-        ctx.sessionAttribute(LoginState.AUTH_FAILED, true)
+        if (succeeded) ctx.sessionAttribute(LoginState.AUTH_FAILED, true)
+        else ctx.sessionAttribute(LoginState.AUTH_ERROR, true)
         ctx.sessionAttribute(LoginState.REDIRECT, loginRedirect)
         ctx.redirect(Web.Uri.LOGIN)
       }

--- a/src/main/kotlin/miquifant/getemall/api/server.kt
+++ b/src/main/kotlin/miquifant/getemall/api/server.kt
@@ -74,7 +74,7 @@ fun startServer(opts: Opts): Javalin {
     get  ("/",                   ServiceController.liveness,   GrantedFor.anyone)
     get  (Admin.Uri.LOGIN_STATE, ServiceController.loginState, GrantedFor.anyone)
     get  (Admin.Uri.LIVENESS,    ServiceController.liveness,   GrantedFor.anyone)
-    get  (Admin.Uri.READINESS,   ServiceController.readiness,  GrantedFor.anyone)
+    get  (Admin.Uri.READINESS,   ServiceController.readiness(userDao), GrantedFor.anyone)
     get  (Admin.Uri.METADATA,    ServiceController.metadata,   GrantedFor.anyone)
     post (Admin.Uri.KILL,        ServiceController.kill(this), GrantedFor.admins)
 

--- a/src/main/resources/vue/views/login.vue
+++ b/src/main/resources/vue/views/login.vue
@@ -1,6 +1,7 @@
     <template id="login">
       <app-frame>
         <form id="loginForm" method="post">
+          <p v-if="loginState.authError" class="verybad notification">Can't log in at the moment. We are having problems.</p>
           <p v-if="loginState.authFailed" class="bad notification">The login information you supplied was incorrect.</p>
           <p v-if="loginState.authSucceeded" class="good notification">Authentication Succeeded.</p>
           <p v-if="loginState.loggedOut" class="notification">You have been logged out.</p>
@@ -65,5 +66,10 @@
       }
       .bad.notification {
         background: #bb0000;
+      }
+      .verybad.notification {
+        background: white;
+        color: red;
+        border: solid 3px red;
       }
     </style>

--- a/src/test/kotlin/miquifant/getemall/controller/TestServiceController.kt
+++ b/src/test/kotlin/miquifant/getemall/controller/TestServiceController.kt
@@ -1,0 +1,32 @@
+package miquifant.getemall.controller
+
+import miquifant.getemall.api.authentication.User
+import miquifant.getemall.api.authentication.UserDao
+import miquifant.getemall.api.authentication.impl.UserListDao
+import miquifant.getemall.api.controller.ComponentCheck
+import miquifant.getemall.api.controller.ServiceController
+import miquifant.getemall.log.Loggable
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TestServiceController {
+
+  // Prepare a UserDao implementation which is never ready, by design
+  object UnreadyUserDao: UserDao {
+    override fun authenticate(username: String?, password: String?, accessLogger: Loggable.Logger): User? = null
+    override fun getUserByUsername(username: String): User? = throw RuntimeException("fail by design")
+  }
+
+  @Test
+  fun testCheckLogin() {
+    val checkReady = ServiceController.checkLogin(UserListDao())
+    val checkUnready = ServiceController.checkLogin(UnreadyUserDao)
+
+    assertEquals(ComponentCheck.ComponentStatus.OK, checkReady.status)
+    assertNull(checkReady.message, "Message should be null")
+
+    assertEquals(ComponentCheck.ComponentStatus.DOWN, checkUnready.status)
+    assertEquals("Login component not ready", checkUnready.message)
+  }
+}


### PR DESCRIPTION
### Description
**feat: implement readiness with login**

Assuming that an userDao will throw an exception when any of its methods
are called, we can implement a first version of `readiness` endpoint.

- Modified `LoginState` to add one more possible state: `AUTH_ERROR`
- Modified login (handler and view) to honor this new state
- Modeled `ServiceReadiness` response with a global status and message,
and a map of component statuses and messages
- Implemented `readiness` endpoint with a single component (login)