### PR TITLE
feat: implement liveness and readiness with login

### DIFF
--- a/src/main/kotlin/miquifant/getemall/api/controller/web.kt
+++ b/src/main/kotlin/miquifant/getemall/api/controller/web.kt
@@ -42,10 +42,16 @@ object LoginController {
     { ctx ->
 
       val loginRedirect = ctx.formParam("redirect")
-      val user = userDao.authenticate(ctx.formParam("username"), ctx.formParam("password"), accessLogger)
+      val (succeeded, user) = try {
 
+        Pair(true, userDao.authenticate(ctx.formParam("username"), ctx.formParam("password"), accessLogger))
+
+      } catch (e: Exception) {
+        Pair(false, null)
+      }
       if (user == null) {
-        ctx.sessionAttribute(LoginState.AUTH_FAILED, true)
+        if (succeeded) ctx.sessionAttribute(LoginState.AUTH_FAILED, true)
+        else ctx.sessionAttribute(LoginState.AUTH_ERROR, true)
         ctx.sessionAttribute(LoginState.REDIRECT, loginRedirect)
         ctx.redirect(Web.Uri.LOGIN)
       }

--- a/src/main/kotlin/miquifant/getemall/api/server.kt
+++ b/src/main/kotlin/miquifant/getemall/api/server.kt
@@ -74,7 +74,7 @@ fun startServer(opts: Opts): Javalin {
     get  ("/",                   ServiceController.liveness,   GrantedFor.anyone)
     get  (Admin.Uri.LOGIN_STATE, ServiceController.loginState, GrantedFor.anyone)
     get  (Admin.Uri.LIVENESS,    ServiceController.liveness,   GrantedFor.anyone)
-    get  (Admin.Uri.READINESS,   ServiceController.readiness,  GrantedFor.anyone)
+    get  (Admin.Uri.READINESS,   ServiceController.readiness(userDao), GrantedFor.anyone)
     get  (Admin.Uri.METADATA,    ServiceController.metadata,   GrantedFor.anyone)
     post (Admin.Uri.KILL,        ServiceController.kill(this), GrantedFor.admins)
 

--- a/src/main/resources/vue/views/login.vue
+++ b/src/main/resources/vue/views/login.vue
@@ -1,6 +1,7 @@
     <template id="login">
       <app-frame>
         <form id="loginForm" method="post">
+          <p v-if="loginState.authError" class="verybad notification">Can't log in at the moment. We are having problems.</p>
           <p v-if="loginState.authFailed" class="bad notification">The login information you supplied was incorrect.</p>
           <p v-if="loginState.authSucceeded" class="good notification">Authentication Succeeded.</p>
           <p v-if="loginState.loggedOut" class="notification">You have been logged out.</p>
@@ -65,5 +66,10 @@
       }
       .bad.notification {
         background: #bb0000;
+      }
+      .verybad.notification {
+        background: white;
+        color: red;
+        border: solid 3px red;
       }
     </style>

--- a/src/test/kotlin/miquifant/getemall/controller/TestServiceController.kt
+++ b/src/test/kotlin/miquifant/getemall/controller/TestServiceController.kt
@@ -1,0 +1,34 @@
+package miquifant.getemall.controller
+
+import miquifant.getemall.api.authentication.User
+import miquifant.getemall.api.authentication.UserDao
+import miquifant.getemall.api.authentication.impl.UserListDao
+import miquifant.getemall.api.controller.ComponentCheck
+import miquifant.getemall.api.controller.ServiceController
+import miquifant.getemall.log.Loggable
+
+import org.junit.Test
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TestServiceController {
+
+  // Prepare a UserDao implementation which is never ready, by design
+  object UnreadyUserDao: UserDao {
+    override fun authenticate(username: String?, password: String?, accessLogger: Loggable.Logger): User? = null
+    override fun getUserByUsername(username: String): User? = throw RuntimeException("fail by design")
+  }
+
+  @Test
+  fun testCheckLogin() {
+    val checkReady = ServiceController.checkLogin(UserListDao())
+    val checkUnready = ServiceController.checkLogin(UnreadyUserDao)
+
+    assertEquals(ComponentCheck.ComponentStatus.OK, checkReady.status)
+    assertNull(checkReady.message, "Message should be null")
+
+    assertEquals(ComponentCheck.ComponentStatus.DOWN, checkUnready.status)
+    assertEquals("Login component not ready", checkUnready.message)
+  }
+}

--- a/src/test/resources/conf/README.md
+++ b/src/test/resources/conf/README.md
@@ -1,5 +1,9 @@
-# Configuration for launching application from the IDE
+# Launching application from the IDE
+
+## Run/Debug configuration
+
 You can configure your IDE to launch application using:
+
 - Main class: `miquifant.getemall.Main`
 - VM options: `-Dlogback.configurationFile=src/test/resources/conf/logback.xml`
 - Program arguments: `serve`


### PR DESCRIPTION
### Description
**feat: implement liveness and readiness with login**

Assuming that an `userDao` will throw an exception when any of its methods
are called, we can implement a first version of `readiness` endpoint.

At the same time we modify the `liveness` endpoint to align with the
other one.

- Modified `LoginState` to add one more possible state: `AUTH_ERROR`
- Modified login (handler and view) to honor this new state
- Modeled `ServiceReadiness` response with a global status and message,
and a map of component statuses and messages
- Implemented `readiness` endpoint with a single component (login)
- Modified `liveness` endpoint to return a json (the same as for
`readiness` endpoint but with an empty list of checked components