### PR TITLE
refactor: create unreadyDb in testing utils module

### DIFF
--- a/src/test/kotlin/miquifant/getemall/api/authentication/impl/TestUsersDatabase.kt
+++ b/src/test/kotlin/miquifant/getemall/api/authentication/impl/TestUsersDatabase.kt
@@ -8,10 +8,10 @@ package miquifant.getemall.api.authentication.impl
 import miquifant.getemall.log.Loggable.Logger
 import miquifant.getemall.log.LoggerFactory
 import miquifant.getemall.testingutils.initDatabaseConnection
+import miquifant.getemall.testingutils.initUnreadyDatabaseConnection
 import miquifant.getemall.utils.AppRole
 import miquifant.getemall.utils.ConnectionManager
 
-import java.sql.DriverManager
 import java.util.*
 
 import kotlin.test.*
@@ -21,12 +21,14 @@ class TestUsersDatabase {
 
   private lateinit var logger: Logger
   private lateinit var db: ConnectionManager
+  private lateinit var unreadyDb: ConnectionManager
   private val tmpDatabase by lazy { "db_${Date().time}" }
 
   @BeforeTest
   fun setup() {
     logger = LoggerFactory.logger(this::class.java.canonicalName)
     db = initDatabaseConnection(tmpDatabase)
+    unreadyDb = initUnreadyDatabaseConnection()
   }
 
   @AfterTest
@@ -46,7 +48,7 @@ class TestUsersDatabase {
     val existingRole2 = AppRole.REGULAR_USER
 
     val usersDao = UserDatabaseDao(db)
-    val unreadyUsersDao = UserDatabaseDao { DriverManager.getConnection("please fail") }
+    val unreadyUsersDao = UserDatabaseDao(unreadyDb)
 
     val unexistingUser = try {
       usersDao.getUserByUsername(unexistingName)
@@ -101,7 +103,7 @@ class TestUsersDatabase {
     val existingRole2  = AppRole.REGULAR_USER
 
     val usersDao = UserDatabaseDao(db)
-    val unreadyUsersDao = UserDatabaseDao { DriverManager.getConnection("please fail") }
+    val unreadyUsersDao = UserDatabaseDao(unreadyDb)
 
     val unexistingUser = try {
       usersDao.authenticate(unexistingName, "whatever", logger)

--- a/src/test/kotlin/miquifant/getemall/controller/TestServiceController.kt
+++ b/src/test/kotlin/miquifant/getemall/controller/TestServiceController.kt
@@ -13,11 +13,11 @@ import miquifant.getemall.api.controller.ComponentStatus.OK
 import miquifant.getemall.api.controller.ServiceController
 import miquifant.getemall.log.Loggable.Logger
 import miquifant.getemall.testingutils.initDatabaseConnection
+import miquifant.getemall.testingutils.initUnreadyDatabaseConnection
 import miquifant.getemall.utils.ConnectionManager
 
 import org.junit.Test
 
-import java.sql.DriverManager
 import java.util.*
 
 import kotlin.test.AfterTest
@@ -29,6 +29,7 @@ import kotlin.test.assertNull
 class TestServiceController {
 
   private lateinit var db: ConnectionManager
+  private lateinit var unreadyDb: ConnectionManager
   private val tmpDatabase by lazy { "db_${Date().time}" }
 
   // Prepare a UserDao implementation which is never ready, by design
@@ -37,12 +38,10 @@ class TestServiceController {
     override fun getUserByUsername(username: String): User? = throw RuntimeException("fail by design")
   }
 
-  // Prepare a ConnectionManager which is never ready, by design
-  private val unreadyDb: ConnectionManager = { DriverManager.getConnection("please fail") }
-
   @BeforeTest
   fun setup() {
     db = initDatabaseConnection(tmpDatabase)
+    unreadyDb = initUnreadyDatabaseConnection()
   }
 
   @AfterTest

--- a/src/test/kotlin/miquifant/getemall/testingutils/db.kt
+++ b/src/test/kotlin/miquifant/getemall/testingutils/db.kt
@@ -16,6 +16,7 @@ import miquifant.getemall.utils.ConnectionParams.USER
 import com.typesafe.config.ConfigFactory
 
 import java.io.File
+import java.sql.DriverManager
 
 
 private const val SCHEMA_DEFINITION_FILE = "database/sql/getemall_schema.sql"
@@ -62,4 +63,11 @@ fun initDatabaseConnection(tmpDatabase: String): ConnectionManager {
   statement.closeOnCompletion()
 
   return db
+}
+
+/**
+ * Creates a ConnectionManager which is never ready, by design.
+ */
+fun initUnreadyDatabaseConnection(): ConnectionManager  = {
+  DriverManager.getConnection("please fail")
 }


### PR DESCRIPTION
### Description
**refactor: create unreadyDb in testing utils module**

Just for testing purposes we created a _`ConnectionManager`_ which is always _unready_ by design, and we refactored tests where we were creating an _unready_ _`ConnectionManager`_ _ad-hoc_.

It will be necessary in the future for testing possible technical errors in CRUD operations on business entities.