### PR TITLE
refactor: add ctx.exception()

### DIFF
--- a/src/main/kotlin/miquifant/getemall/api/controller/service.kt
+++ b/src/main/kotlin/miquifant/getemall/api/controller/service.kt
@@ -91,7 +91,7 @@ object ServiceController {
           "Access denied to '${ctx.matchedPath()}' for user '${user?.name ?: "anonymous"}' with role '$role'"
         }
         // Capture it with a Content-Type:"html" specific 401 error filter, to redirect to login or unauthorized page
-        ctx.status(401).json(ExceptionalResponse.unauthorized)
+        ctx.exception(ExceptionalResponse.unauthorized)
       }
     }
   }
@@ -118,6 +118,7 @@ object ServiceController {
 
   val exceptionHandler: ExceptionHandler = { e, ctx ->
     logger.errorWithThrowable(e) { "An error occurred: ${e.message}" }
+    // TODO As the application becomes more "production ready" this response should disappear
     ctx.status(500).json(e)
   }
 

--- a/src/main/kotlin/miquifant/getemall/model/api_entities.kt
+++ b/src/main/kotlin/miquifant/getemall/model/api_entities.kt
@@ -14,6 +14,8 @@ data class ExceptionalResponse(val code: Int, val message: String) {
 
   companion object {
 
+    val unknownError = ExceptionalResponse(500, "Unknown error")
+
     val badRequest   = ExceptionalResponse(400, "Bad request")
     val unauthorized = ExceptionalResponse(401, "Unauthorized")
     val notFound     = ExceptionalResponse(404, "Not found")

--- a/src/main/kotlin/miquifant/getemall/utils/javalin_utils.kt
+++ b/src/main/kotlin/miquifant/getemall/utils/javalin_utils.kt
@@ -5,6 +5,8 @@
  */
 package miquifant.getemall.utils
 
+import miquifant.getemall.model.ExceptionalResponse
+import miquifant.getemall.model.ExceptionalResponse.Companion.unknownError
 import miquifant.getemall.utils.AppRole.*
 
 import io.javalin.core.security.Role
@@ -26,4 +28,12 @@ internal object GrantedFor {
   val admins        = setOf(ADMIN)
   val loggedInUsers = admins + setOf(REGULAR_USER)
   val anyone        = loggedInUsers + setOf(ANONYMOUS)
+}
+
+fun Context.exception(code: Int, message: String): Context {
+  return this.exception(ExceptionalResponse(code, message))
+}
+
+fun Context.exception(res: ExceptionalResponse = unknownError): Context {
+  return this.status(res.code).json(res)
 }

--- a/src/test/kotlin/miquifant/getemall/model/TestApiEntities.kt
+++ b/src/test/kotlin/miquifant/getemall/model/TestApiEntities.kt
@@ -10,6 +10,7 @@ import miquifant.getemall.model.ExceptionalResponse.Companion.inserted
 import miquifant.getemall.model.ExceptionalResponse.Companion.notFound
 import miquifant.getemall.model.ExceptionalResponse.Companion.ok
 import miquifant.getemall.model.ExceptionalResponse.Companion.unauthorized
+import miquifant.getemall.model.ExceptionalResponse.Companion.unknownError
 import miquifant.getemall.persistence.SQLReturnCode
 
 import kotlin.test.Test
@@ -17,6 +18,12 @@ import kotlin.test.assertEquals
 
 
 class TestApiEntities {
+
+  @Test
+  fun testUnknownError() {
+    assertEquals(500, unknownError.code)
+    assertEquals("Unknown error", unknownError.message)
+  }
 
   @Test
   fun testBadRequest() {


### PR DESCRIPTION
### Description
**refactor: add ctx.exception()**

Added extension function of `Context` for controlling exceptional
responses in a single call, instead of setting status and body
separately