### PR TITLE
Feat add profiles

### DIFF
--- a/src/main/kotlin/miquifant/getemall/api/controller/profiles.kt
+++ b/src/main/kotlin/miquifant/getemall/api/controller/profiles.kt
@@ -1,0 +1,81 @@
+/**
+ * URIs and Handlers for application profiles.
+ *
+ * Created by miquifant on 2020-12-24
+ */
+package miquifant.getemall.api.controller
+
+import miquifant.getemall.log.LoggerFactory
+import miquifant.getemall.model.ExceptionalResponse
+import miquifant.getemall.persistence.*
+import miquifant.getemall.utils.ConnectionManager
+import miquifant.getemall.utils.Handler
+import miquifant.getemall.utils.exception
+
+
+object Profiles {
+  object Uri {
+    const val PROFILES        = "/api/profiles"
+    const val PROFILE_BY_NAME = "/api/profiles/name/:name"
+    const val ONE_PROFILE     = "/api/profiles/:id"
+  }
+}
+
+object ProfilesController {
+
+  private val logger = LoggerFactory.logger(this::class.java.canonicalName)
+
+  val getAll: (ConnectionManager) -> Handler = { db ->
+    { ctx ->
+      val (ret, profiles) = retrieveProfilesList(db, logger)
+      when (ret) {
+
+        // 200 Ok
+        SQLReturnCode.Succeeded -> ctx.json(profiles)
+
+        // 503 Service Unavailable: If a technical error occurred "Service unavailable"
+        else -> ctx.exception(ExceptionalResponse.fromSQLReturnCode(ret))
+      }
+    }
+  }
+
+  val getOne: (ConnectionManager) -> Handler = { db ->
+    { ctx ->
+      val id = try { ctx.pathParam<Int>("id").getOrNull() } catch (e: Exception) { null }
+      if (id != null) {
+        val (ret, profiles) = retrieveProfile(id, db, logger)
+        when {
+
+          // 200 Ok
+          ret == SQLReturnCode.Succeeded && profiles.isNotEmpty() -> ctx.json(profiles[0])
+
+          // 404 Not found
+          profiles.isEmpty() -> ctx.status(404)
+
+          // 503 Service Unavailable: If a technical error occurred "Service unavailable"
+          else -> ctx.exception(ExceptionalResponse.fromSQLReturnCode(ret))
+        }
+      }
+      // 400 Bad request
+      else ctx.exception(400, "Wrong id '${ctx.pathParam("id")}'. It should be an integer number")
+    }
+  }
+
+  val getByName: (ConnectionManager) -> Handler = { db ->
+    { ctx ->
+      val name = ctx.pathParam<String>("name").get()
+      val (ret, profiles) = retrieveProfile(name, db, logger)
+      when {
+
+        // 200 Ok
+        ret == SQLReturnCode.Succeeded && profiles.isNotEmpty() -> ctx.json(profiles[0])
+
+        // 404 Not found
+        profiles.isEmpty() -> ctx.status(404)
+
+        // 503 Service Unavailable: If a technical error occurred "Service unavailable"
+        else -> ctx.exception(ExceptionalResponse.fromSQLReturnCode(ret))
+      }
+    }
+  }
+}

--- a/src/main/kotlin/miquifant/getemall/api/server.kt
+++ b/src/main/kotlin/miquifant/getemall/api/server.kt
@@ -9,7 +9,9 @@ package miquifant.getemall.api
 import miquifant.getemall.api.authentication.impl.UserDatabaseDao
 import miquifant.getemall.api.controller.Admin
 import miquifant.getemall.api.controller.LoginController
+import miquifant.getemall.api.controller.Profiles
 import miquifant.getemall.api.controller.ServiceController
+import miquifant.getemall.api.controller.ProfilesController
 import miquifant.getemall.api.controller.Web
 import miquifant.getemall.command.Opts
 import miquifant.getemall.command.loadFullConfig
@@ -81,6 +83,11 @@ fun startServer(opts: Opts): Javalin {
     get  (Admin.Uri.READINESS,   ServiceController.readiness(userDao, db), GrantedFor.anyone)
     get  (Admin.Uri.METADATA,    ServiceController.metadata,   GrantedFor.anyone)
     post (Admin.Uri.KILL,        ServiceController.kill(this), GrantedFor.admins)
+
+    // Profiles cRud
+    get (Profiles.Uri.PROFILES, ProfilesController.getAll(db), GrantedFor.admins)
+    get (Profiles.Uri.ONE_PROFILE, ProfilesController.getOne(db), GrantedFor.anyone)
+    get (Profiles.Uri.PROFILE_BY_NAME, ProfilesController.getByName(db), GrantedFor.anyone)
 
     /* =========================================================================================
      *  Web

--- a/src/main/kotlin/miquifant/getemall/model/db_entities.kt
+++ b/src/main/kotlin/miquifant/getemall/model/db_entities.kt
@@ -1,0 +1,19 @@
+@file:JvmName("DBEntities")
+/**
+ * Data classes with DB entities in getemall schema.
+ *
+ * Created by miquifant on 2020-11-09
+ */
+package miquifant.getemall.model
+
+import java.sql.Timestamp
+
+
+data class Profile(val id: Int,
+                   val email: String,
+                   val name: String,
+                   val fullname: String,
+                   val role: Int,
+                   val timestamp: Timestamp,
+                   val verified: Boolean,
+                   val active: Boolean)

--- a/src/main/kotlin/miquifant/getemall/persistence/profiles_db.kt
+++ b/src/main/kotlin/miquifant/getemall/persistence/profiles_db.kt
@@ -1,0 +1,125 @@
+@file:JvmName("PersistenceProfiles")
+/**
+ * Persistence module with SQL statements and DB access functions for managing Profiles.
+ *
+ * Created by miquifant on 2020-12-28
+ */
+package miquifant.getemall.persistence
+
+import miquifant.getemall.log.Loggable
+import miquifant.getemall.model.Profile
+import miquifant.getemall.utils.ConnectionManager
+
+
+private object SQLprofile {
+
+  val list = """
+    |SELECT id, email, nickname, fullname, role, timestamp, verified, active
+    |FROM users
+    |ORDER BY id
+  """.trimMargin().trim()
+
+  val show = """
+    |SELECT id, email, nickname, fullname, role, timestamp, verified, active
+    |FROM users
+    |WHERE id = ?
+  """.trimMargin().trim()
+
+  val showByName = """
+    |SELECT id, email, nickname, fullname, role, timestamp, verified, active
+    |FROM users
+    |WHERE nickname = ?
+  """.trimMargin().trim()
+}
+
+fun retrieveProfilesList(db: ConnectionManager, logger: Loggable.Logger):
+    Pair<SQLReturnCode, List<Profile>>
+{
+  val ret = mutableListOf<Profile>()
+  return try {
+    val stmt = db().prepareStatement(SQLprofile.list)
+    val rs = stmt.executeQuery()
+    while (rs.next()) {
+      ret.add(Profile(
+          id = rs.getInt(1),
+          email = rs.getString(2),
+          name = rs.getString(3),
+          fullname = if (rs.getObject(4) != null) rs.getString(4) else rs.getString(3),
+          role = rs.getInt(5),
+          timestamp = rs.getTimestamp(6),
+          verified = rs.getBoolean(7),
+          active = rs.getBoolean(8)
+      ))
+    }
+    stmt.closeOnCompletion()
+    Pair(SQLReturnCode.Succeeded, ret)
+  }
+  // Technical (like connection error)
+  catch (e: Exception) {
+    val message = "Unable to recover profiles list due an internal error"
+    logger.errorWithThrowable(e) { "$message: ${e.message}" }
+    Pair(SQLReturnCode.DBError(message), ret)
+  }
+}
+
+fun retrieveProfile(id: Int, db: ConnectionManager, logger: Loggable.Logger):
+    Pair<SQLReturnCode, List<Profile>>
+{
+  val ret = mutableListOf<Profile>()
+  return try {
+    val stmt = db().prepareStatement(SQLprofile.show).apply {
+      setInt(1, id)
+    }
+    val rs = stmt.executeQuery()
+    if (rs.next())
+      ret.add(Profile(
+          id = id,
+          email = rs.getString(2),
+          name = rs.getString(3),
+          fullname = if (rs.getObject(4) != null) rs.getString(4) else rs.getString(3),
+          role = rs.getInt(5),
+          timestamp = rs.getTimestamp(6),
+          verified = rs.getBoolean(7),
+          active = rs.getBoolean(8)
+      ))
+    stmt.closeOnCompletion()
+    Pair(SQLReturnCode.Succeeded, ret)
+  }
+  // Technical (like connection error)
+  catch (e: Exception) {
+    val message = "Unable to recover profile id='$id' due an internal error"
+    logger.errorWithThrowable(e) { "$message: ${e.message}" }
+    Pair(SQLReturnCode.DBError(message), ret)
+  }
+}
+
+fun retrieveProfile(name: String, db: ConnectionManager, logger: Loggable.Logger):
+    Pair<SQLReturnCode, List<Profile>>
+{
+  val ret = mutableListOf<Profile>()
+  return try {
+    val stmt = db().prepareStatement(SQLprofile.showByName).apply {
+      setString(1, name)
+    }
+    val rs = stmt.executeQuery()
+    if (rs.next())
+      ret.add(Profile(
+          id = rs.getInt(1),
+          email = rs.getString(2),
+          name = name,
+          fullname = if (rs.getObject(4) != null) rs.getString(4) else rs.getString(3),
+          role = rs.getInt(5),
+          timestamp = rs.getTimestamp(6),
+          verified = rs.getBoolean(7),
+          active = rs.getBoolean(8)
+      ))
+    stmt.closeOnCompletion()
+    Pair(SQLReturnCode.Succeeded, ret)
+  }
+  // Technical (like connection error)
+  catch (e: Exception) {
+    val message = "Unable to recover profile '$name' due an internal error"
+    logger.errorWithThrowable(e) { "$message: ${e.message}" }
+    Pair(SQLReturnCode.DBError(message), ret)
+  }
+}

--- a/src/main/resources/assets/getemall.js
+++ b/src/main/resources/assets/getemall.js
@@ -1,0 +1,44 @@
+/*!
+ * getemall.js
+ * (c) 2020 Miquifant
+ */
+const getResponseOrBreak = (jsonData) => {
+  // the attribute 'id' is expected for every returned entity,
+  // except when returned object is an error (code, message)
+  if (jsonData.id) return jsonData;
+  else throw Error(jsonData.message || jsonData.title || "unknown error");
+};
+const getResponseArrayOrBreak = (jsonData) => {
+  // an array is expected unless there is an error
+  if (Array.isArray(jsonData)) return jsonData;
+  else throw Error(jsonData.message || jsonData.title || "unknown error");
+};
+const handleFetchList = (endpoint, handler, errHandler) => {
+  return fetch("/api/" + endpoint, {
+      method: "get"
+  }).then(res => res.json())
+    .then(getResponseArrayOrBreak)
+    .then(handler)
+    .catch((e) => {
+        console.log("Error fetching " + endpoint + ": " + e);
+        if (errHandler) errHandler(e);
+        else alert(e.message);
+    })
+};
+const handleFetch = (endpoint, query, handler, errHandler) => {
+  return fetch("/api/" + endpoint + "/" + query, {
+      method: "get"
+  }).then(res => {
+        // when res.status is 404 server doesn't send any json, so we create it
+        if (res.status == 404)
+          return JSON.parse('{"code":"'+res.status+'","message":"Not found"}')
+        else return res.json()
+    })
+    .then(getResponseOrBreak)
+    .then(handler)
+    .catch((e) => {
+        console.log("Error fetching " + endpoint + ": " + e);
+        if (errHandler) errHandler(e);
+        else alert(e.message);
+    })
+};

--- a/src/main/resources/vue/layout.html
+++ b/src/main/resources/vue/layout.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/webjars/bootstrap/3.4.1/css/bootstrap.min.css">
     <script src="/webjars/bootstrap/3.4.1/js/bootstrap.min.js"></script>
     <link rel="stylesheet" href="/getemall.css" />
+    <script src="/getemall.js"></script>
     <script src="/webjars/vue/2.6.10/dist/vue.min.js"></script>
     @componentRegistration
   </head>

--- a/src/main/resources/vue/views/not-found.vue
+++ b/src/main/resources/vue/views/not-found.vue
@@ -1,6 +1,6 @@
 <template id="not-found">
   <app-frame>
-    <h1>We can't find the page you're looking for<h1>
+    <h1>We can't find the page you're looking for</h1>
     <h2><small>(error 404)</small></h2>
   </app-frame>
 </template>

--- a/src/main/resources/vue/views/view-1.vue
+++ b/src/main/resources/vue/views/view-1.vue
@@ -6,12 +6,12 @@
 </template>
 
 <script>
-  Vue.component("view-1", {
-    template: "#view-1",
-    mounted: function() {
-      $("#v1-tab").tab("show")
-    }
-  });
+Vue.component("view-1", {
+  template: "#view-1",
+  mounted: function() {
+    $("#v1-tab").tab("show")
+  }
+});
 </script>
 
 <style>

--- a/src/main/resources/vue/views/view-2.vue
+++ b/src/main/resources/vue/views/view-2.vue
@@ -2,20 +2,41 @@
   <app-frame>
     <h1 class="title-view-2">This is the second view</h1>
     <h2>Only for logged in users (like you, <strong>{{ $javalin.state.currentUser }}</strong>)</h2>
+    <div>
+      <pre v-if="profile">{{ profile }}</pre>
+      <pre v-else>{{ error }}</pre>
+    </div>
   </app-frame>
 </template>
 
 <script>
-  Vue.component("view-2", {
-    template: "#view-2",
-    mounted: function() {
-      $("#v2-tab").tab("show")
+Vue.component("view-2", {
+  template: "#view-2",
+  data: () => ({
+    profile: null,
+    error: null
+  }),
+  methods: {
+    setProfile: function() {
+      // Set Getemall profile from logged-in user
+      handleFetch("profiles",
+        "name/" + this.$javalin.state.currentUser,
+        profile => this.profile = profile,
+        e => this.error = e.message);
     }
-  });
+  },
+  mounted: function() {
+    $("#v2-tab").tab("show");
+    this.setProfile();
+  }
+});
 </script>
 
 <style>
 .title-view-2 {
   color: orange;
+}
+pre {
+  margin-top: 20px;
 }
 </style>

--- a/src/main/resources/vue/views/view-3.vue
+++ b/src/main/resources/vue/views/view-3.vue
@@ -6,12 +6,12 @@
 </template>
 
 <script>
-  Vue.component("view-3", {
-    template: "#view-3",
-    mounted: function() {
-      $("#v3-tab").tab("show")
-    }
-  });
+Vue.component("view-3", {
+  template: "#view-3",
+  mounted: function() {
+    $("#v3-tab").tab("show")
+  }
+});
 </script>
 
 <style>

--- a/src/test/kotlin/miquifant/getemall/persistence/TestPersistenceProfiles.kt
+++ b/src/test/kotlin/miquifant/getemall/persistence/TestPersistenceProfiles.kt
@@ -1,0 +1,117 @@
+/**
+ * Test persistence functions for Profiles.
+ *
+ * Created by miquifant on 2020-12-29
+ */
+package miquifant.getemall.persistence
+
+import miquifant.getemall.log.Loggable.Logger
+import miquifant.getemall.log.LoggerFactory
+import miquifant.getemall.testingutils.initDatabaseConnection
+import miquifant.getemall.utils.ConnectionManager
+
+import java.util.*
+
+import kotlin.test.*
+
+
+class TestPersistenceProfiles {
+
+  private lateinit var logger: Logger
+  private lateinit var db: ConnectionManager
+  private val tmpDatabase by lazy { "db_${Date().time}" }
+
+  @BeforeTest
+  fun setup() {
+    logger = LoggerFactory.logger(this::class.java.canonicalName)
+    db = initDatabaseConnection(tmpDatabase)
+  }
+
+  @AfterTest
+  fun disposeDatabaseConnection() {
+    db().close()
+  }
+
+  @Test
+  fun testRetrieveProfilesList() {
+    assertNotNull(db(), "Unable to execute test due an error with database connection")
+
+    val (ret, profiles) = retrieveProfilesList(db, logger)
+    assertEquals(SQLReturnCode.Succeeded, ret)
+    assertEquals(4, profiles.size)
+
+    val connection = db()
+    connection.createStatement().execute("TRUNCATE TABLE users")
+    val (retEmpty, noProfiles) = retrieveProfilesList(db, logger)
+    assertEquals(SQLReturnCode.Succeeded, retEmpty)
+    assertEquals(0, noProfiles.size)
+
+    // -----------
+    // TEST ERRORS
+    // -----------
+
+    // Will fail due technical error (like connection error)
+    connection.close()
+
+    val (retKO, emptyList) = retrieveProfilesList(db, logger)
+    assertTrue(retKO is SQLReturnCode.DBError, "Query should fail")
+    assertEquals("Unable to recover profiles list due an internal error", retKO.message)
+    assertTrue(emptyList.isEmpty(), "Query should return no results")
+  }
+
+  @Test
+  fun testRetrieveProfileById() {
+    assertNotNull(db(), "Unable to execute test due an error with database connection")
+
+    val existingProfile = 1
+    val unexistingProfile = 0
+
+    val (ret1, profilesWithExistingId) = retrieveProfile(existingProfile, db, logger)
+    assertEquals(SQLReturnCode.Succeeded, ret1)
+    assertEquals(1, profilesWithExistingId.size)
+
+    val (ret2, profilesWithUnexistingId) = retrieveProfile(unexistingProfile, db, logger)
+    assertEquals(SQLReturnCode.Succeeded, ret2)
+    assertEquals(0, profilesWithUnexistingId.size)
+
+    // -----------
+    // TEST ERRORS
+    // -----------
+
+    // Will fail due technical error (like connection error)
+    db().close()
+
+    val (retKO, emptyList) = retrieveProfile(existingProfile, db, logger)
+    assertTrue(retKO is SQLReturnCode.DBError, "Return should be DBError")
+    assertEquals("Unable to recover profile id='$existingProfile' due an internal error", retKO.message)
+    assertTrue(emptyList.isEmpty(), "Query should return no results")
+  }
+
+  @Test
+  fun testRetrieveProfileByName() {
+    assertNotNull(db(), "Unable to execute test due an error with database connection")
+
+    val existingProfileName = "miqui"
+    val unexistingProfileName = "unexisting"
+
+    val (ret1, profilesWithExistingName) = retrieveProfile(existingProfileName, db, logger)
+    assertEquals(SQLReturnCode.Succeeded, ret1)
+    assertEquals(1, profilesWithExistingName.size)
+
+    val (ret2, profilesWithUnexistingName) = retrieveProfile(unexistingProfileName, db, logger)
+    assertEquals(SQLReturnCode.Succeeded, ret2)
+    assertEquals(0, profilesWithUnexistingName.size)
+
+    // -----------
+    // TEST ERRORS
+    // -----------
+
+    // Will fail due technical error (like connection error)
+    db().close()
+
+    val (retKO, emptyList) = retrieveProfile(existingProfileName, db, logger)
+    assertTrue(retKO is SQLReturnCode.DBError, "Return should be DBError")
+    assertEquals("Unable to recover profile '$existingProfileName' due an internal error", retKO.message)
+    assertTrue(emptyList.isEmpty(), "Query should return no results")
+  }
+}


### PR DESCRIPTION
### Description
**feat: add profiles**

Added management of profiles (getemall users) in readonly mode, both back and front layers.

_Back-end_
- Created a `Profile` class in `db_entities` of the model package
- Created a _Profiles Controller_ with the definition of the exposed endpoints (`/api/profiles`, `/api/profiles/name/:name`, `/api/profiles/:id`) and functions (`getAll`, `getOne`, `getByName`)
- Added endpoints to server
- Created a _Data Access module_ for Profiles with sql and db stuff

_Front-end_
- Created a `getemall.js` file to implement some utils like: `handleFetch` and `handleFetchList`, which simplify a little the management of errors on calls to the API
- Added to `layout.html`
- Minor fixes in views `not-found.vue`, `view-1.vue` and `view-3.vue`
- Modified View-2 to illustrate the use of handlers and access the new endpoint `/api/profiles/name/:name`, retrieving and showing the profile of the logged-in user