### PR TITLE
feat-ui: add load-profile component

### DIFF
--- a/src/main/resources/vue/components/profile-loader.vue
+++ b/src/main/resources/vue/components/profile-loader.vue
@@ -1,0 +1,29 @@
+<template id="profile-loader">
+  <div v-if="error" class="alert alert-warning alert-dismissible fade in login-message" role="alert">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    <i class="glyphicon glyphicon-warning-sign"></i>
+    <span>{{ error }}</span>
+  </div>
+</template>
+<script>
+Vue.component("profile-loader", {
+  template: "#profile-loader",
+  props: [ "parent" ],
+  data: () => ({
+    error: null
+  }),
+  methods: {
+    setProfile: function() {
+      // Set Getemall profile from logged-in user
+      handleFetch("profiles",
+        "name/" + this.$javalin.state.currentUser,
+        profile => this.parent.profile = profile,
+        e => this.error = e.message);
+    }
+  },
+  mounted: function() {
+    if (this.parent) this.setProfile();
+    else this.error = "Unable to retrieve profile information";
+  }
+});
+</script>

--- a/src/main/resources/vue/views/view-2.vue
+++ b/src/main/resources/vue/views/view-2.vue
@@ -1,10 +1,11 @@
 <template id="view-2">
   <app-frame>
+    <profile-loader :parent="this"></profile-loader>
     <h1 class="title-view-2">This is the second view</h1>
     <h2>Only for logged in users (like you, <strong>{{ $javalin.state.currentUser }}</strong>)</h2>
     <div>
       <pre v-if="profile">{{ profile }}</pre>
-      <pre v-else>{{ error }}</pre>
+      <pre v-else>Profile info not found</pre>
     </div>
   </app-frame>
 </template>
@@ -13,21 +14,10 @@
 Vue.component("view-2", {
   template: "#view-2",
   data: () => ({
-    profile: null,
-    error: null
+    profile: null
   }),
-  methods: {
-    setProfile: function() {
-      // Set Getemall profile from logged-in user
-      handleFetch("profiles",
-        "name/" + this.$javalin.state.currentUser,
-        profile => this.profile = profile,
-        e => this.error = e.message);
-    }
-  },
   mounted: function() {
     $("#v2-tab").tab("show");
-    this.setProfile();
   }
 });
 </script>


### PR DESCRIPTION
### Description
**feat-ui: add load-profile component**

There will be many places where we'll need to load the profile information of current user, and we don't want to have the logic of
retrieving that info replicated in all those pages, so we created a component that fetches the profile info and stores it in parent's
property `profile`.

- Created `profile-loader.vue`
- And refactored `view-2.vue` to use it