### PR TITLE
feat: add pub_email_v column to profiles table

### DIFF
--- a/database/sql/getemall_schema.sql
+++ b/database/sql/getemall_schema.sql
@@ -56,7 +56,8 @@ CREATE TABLE IF NOT EXISTS profiles (
   `profile_pic` varchar(128)                        COMMENT 'User profile picture name',
   `full_name`   varchar(128)                        COMMENT 'User full name',
   `pub_email`   varchar(128)                        COMMENT 'Public email',
-  `bio`         text                                COMMENT 'User bio',
+  `pub_email_v` boolean      NOT NULL DEFAULT false COMMENT 'Public email is verified',
+  `bio`         varchar(256)                        COMMENT 'User bio',
   `timestamp`   timestamp    NOT NULL DEFAULT NOW() COMMENT 'Last update timestamp',
   CONSTRAINT profile_PK PRIMARY KEY (id),
   CONSTRAINT profile_user_FK FOREIGN KEY (id)

--- a/src/main/kotlin/miquifant/getemall/model/db_entities.kt
+++ b/src/main/kotlin/miquifant/getemall/model/db_entities.kt
@@ -12,6 +12,7 @@ import java.sql.Timestamp
 data class ProfileExt(val profilePic: String? = null,
                       val fullName: String? = null,
                       val pubEmail: String? = null,
+                      val pubEmailVerified: Boolean = false,
                       val bio: String? = null)
 
 data class Profile(val id: Int,

--- a/src/main/kotlin/miquifant/getemall/persistence/profiles_db.kt
+++ b/src/main/kotlin/miquifant/getemall/persistence/profiles_db.kt
@@ -20,7 +20,9 @@ private object SQLprofile {
   val constraints: List<Constraint> = listOf(
       Constraint(Regex("(?i).*user_email_UN.*"), SQLReturnCode.UniqueError("Email already exists")),
       Constraint(Regex("(?i).*user_name_UN.*"), SQLReturnCode.UniqueError("Username already taken")),
-      Constraint(Regex("(?i).*user_superpowers_FK.*"), SQLReturnCode.FKError("Invalid role"))
+      Constraint(Regex("(?i).*user_superpowers_FK.*"), SQLReturnCode.FKError("Invalid role")),
+      Constraint(Regex("(?i).*profile_PK.*"), SQLReturnCode.FKError("Id already taken")),
+      Constraint(Regex("(?i).*profile_user_FK.*"), SQLReturnCode.FKError("Invalid user"))
   )
 
   val list = """
@@ -31,7 +33,7 @@ private object SQLprofile {
 
   val show = """
     |SELECT u.id, u.email, u.nickname, u.role, u.timestamp, u.verified, u.active,
-    |       p.profile_pic, p.full_name, p.pub_email, p.bio
+    |       p.profile_pic, p.full_name, p.pub_email, p.pub_email_v, p.bio
     |FROM users u
     |  LEFT OUTER JOIN profiles p
     |    ON p.id = u.id
@@ -40,7 +42,7 @@ private object SQLprofile {
 
   val showByName = """
     |SELECT u.id, u.email, u.nickname, u.role, u.timestamp, u.verified, u.active,
-    |       p.profile_pic, p.full_name, p.pub_email, p.bio
+    |       p.profile_pic, p.full_name, p.pub_email, p.pub_email_v, p.bio
     |FROM users u
     |  LEFT OUTER JOIN profiles p
     |    ON p.id = u.id
@@ -112,7 +114,8 @@ fun retrieveProfile(id: Int, db: ConnectionManager, logger: Logger):
               profilePic = rs.getObject(8)?.toString(),
               fullName = rs.getObject(9)?.toString(),
               pubEmail = rs.getObject(10)?.toString(),
-              bio = rs.getObject(11)?.toString()
+              pubEmailVerified = rs.getBoolean(11),
+              bio = rs.getObject(12)?.toString()
           )
       ))
     stmt.closeOnCompletion()
@@ -148,7 +151,8 @@ fun retrieveProfile(name: String, db: ConnectionManager, logger: Logger):
               profilePic = rs.getObject(8)?.toString(),
               fullName = rs.getObject(9)?.toString(),
               pubEmail = rs.getObject(10)?.toString(),
-              bio = rs.getObject(11)?.toString()
+              pubEmailVerified = rs.getBoolean(11),
+              bio = rs.getObject(12)?.toString()
           )
       ))
     stmt.closeOnCompletion()

--- a/src/main/resources/vue/views/profile.vue
+++ b/src/main/resources/vue/views/profile.vue
@@ -52,6 +52,8 @@
           <li v-if="profile.ext.pubEmail" class="vcard-detail">
             <i class="glyphicon glyphicon-envelope"></i>
             <a :href="'mailto:' + profile.ext.pubEmail">{{ profile.ext.pubEmail }}</a>
+            <i v-if="profile.ext.pubEmailVerified" class="glyphicon glyphicon-ok-sign green" title="verified"></i>
+            <i v-else class="glyphicon glyphicon-remove-sign red" title="unverified"></i>
           </li>
           <li v-if="profile.ext.websiteUrl" class="vcard-detail">
             <i class="glyphicon glyphicon-link"></i>

--- a/src/main/resources/vue/views/settings/account.vue
+++ b/src/main/resources/vue/views/settings/account.vue
@@ -150,10 +150,12 @@ Vue.component("settings-account", {
 .form-control-feedback {
   display: none;
 }
-#feedback-username.glyphicon-ok {
+#feedback-username.glyphicon-ok,
+.glyphicon.green {
   color: #5ab034;
 }
-#feedback-username.glyphicon-warning-sign {
+#feedback-username.glyphicon-warning-sign,
+.glyphicon.red {
   color: #bf1515;
 }
 .loader {


### PR DESCRIPTION
### Description
**feat: add pub_email_v column to profiles table**

- Added field to indicate that the public email provided by the user has been verified, and propagated to the ui.
- Also two boyscoutting changes were made:
  * limited size of `bio` column to 256 characters
  * documented 2 more constraints in users/profiles datamodel

### Issue
resolves #41 